### PR TITLE
Fix armband insurance exploit when armband is kept on death.

### DIFF
--- a/WTT-PackNStrap/Patches/IsItemKeptAfterDeathPatch.cs
+++ b/WTT-PackNStrap/Patches/IsItemKeptAfterDeathPatch.cs
@@ -41,5 +41,4 @@ public class IsItemKeptAfterDeathPatch : AbstractPatch
         return item.Id == armBandItem.Id || 
                inventoryItems.GetItemWithChildren(armBandItem.Id).Any(i => i.Id == item.Id);
     }
-
 }

--- a/WTT-PackNStrap/WTTPackNStrap.cs
+++ b/WTT-PackNStrap/WTTPackNStrap.cs
@@ -81,6 +81,13 @@ public class WTTPackNStrap(
             var lostOnDeathConfig = configServer.GetConfig<LostOnDeathConfig>();
             lostOnDeathConfig.Equipment.ArmBand = true;
             new IsItemKeptAfterDeathPatch().Enable();
+            foreach (var caseId in ContainerIds.Items)
+            {
+                if (_itemsDb.TryGetValue(caseId, out var item))
+                {
+                    item.Properties.InsuranceDisabled = true;
+                }
+            }
         }
 
         if (config is { addCasesToSecureContainers: true })
@@ -173,7 +180,6 @@ public class WTTPackNStrap(
             Type = "Node",
             Properties = new TemplateItemProperties()
         };
-
     }
 }
 


### PR DESCRIPTION
Insuring armbands while they're allowed to be kept on death results in you keeping your original armband, and it's contents, while also gaining the insured item return, and it's contents.

While the servermod checks for `loseArmbandOnDeath: false` it goes over the list of container IDs and makes them uninsurable (item.Properties.InsuranceDisabled = true)