### PR TITLE
Actually make cases MobContainers when added to secure containers

### DIFF
--- a/WTT-PackNStrap/WTTPackNStrap.cs
+++ b/WTT-PackNStrap/WTTPackNStrap.cs
@@ -7,6 +7,7 @@ using SPTarkov.Server.Core.Services;
 using Range = SemanticVersioning.Range;
 using SPTarkov.Server.Core.Helpers;
 using SPTarkov.Server.Core.Models.Common;
+using SPTarkov.Server.Core.Models.Enums;
 using SPTarkov.Server.Core.Models.Spt.Config;
 using SPTarkov.Server.Core.Servers;
 using SPTarkov.Server.Core.Utils;
@@ -108,6 +109,13 @@ public class WTTPackNStrap(
                             continue;
                         }
 
+                        item.Parent = "5448bf274bdc2dfc2f8b456a";
+                        item.Properties?.IsSecured = true;
+                        item.Properties?.CantRemoveFromSlotsDuringRaid = 
+                        [ 
+                            EquipmentSlots.SecuredContainer
+                        ];
+                        
                         var grids = item.Properties?.Grids?.ToList();
                         if (grids?.Count > 0)
                         {


### PR DESCRIPTION
added section

```csharp  
item.Parent = "5448bf274bdc2dfc2f8b456a";
item.Properties?.IsSecured = true;
item.Properties?.CantRemoveFromSlotsDuringRaid = 
[ 
    EquipmentSlots.SecuredContainer
];
```

to secure container config logic.

This did not break anything when doing the changes manually in the json files, you're free to take this if you want or don't if you know it'll break things later on down the line